### PR TITLE
Added URL scheme support

### DIFF
--- a/mauth/Info.plist
+++ b/mauth/Info.plist
@@ -14,6 +14,15 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mauth</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleShortVersionString</key>
 	<string>1.1</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
You can now open app by URL mauth://

Обновил описание в info.plist, чтобы приложение можно было вызывать по URL mauth://
Теперь приложение можно запускать через Launch Center Pro и другие лончеры, в том числе из Today Widget.

Инструкцию взял [отсюда](http://stackoverflow.com/questions/8201724/how-to-register-a-custom-app-opening-url-scheme-with-xcode-4).
Проверил, у меня всё работает.
